### PR TITLE
fix: escape last period to match only milliseconds (#1239)

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -26,5 +26,5 @@ export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ'
 export const INVALID_DATE_STRING = 'Invalid Date'
 
 // regex
-export const REGEX_PARSE = /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?.?(\d+)?$/
+export const REGEX_PARSE = /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?\.?(\d+)?$/
 export const REGEX_FORMAT = /\[([^\]]+)]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -149,10 +149,10 @@ describe('REGEX_PARSE', () => {
     expect(d.join('-')).toBe('2019-03-25T06:41:00.999999999-2019-03-25-06-41-00-999999999')
   })
   it('20210102T012345', () => {
-	const date = '20210102T012345'
-	const d = date.match(REGEX_PARSE)
-	expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
-	expect(d.join('-')).toBe('20210102T012345-2021-01-02-01-23-45-')
+    const date = '20210102T012345'
+    const d = date.match(REGEX_PARSE)
+    expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
+    expect(d.join('-')).toBe('20210102T012345-2021-01-02-01-23-45-')
   })
   it('2021-01-02T01:23', () => {
     const date = '2021-01-02T01:23'

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -148,4 +148,34 @@ describe('REGEX_PARSE', () => {
     expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
     expect(d.join('-')).toBe('2019-03-25T06:41:00.999999999-2019-03-25-06-41-00-999999999')
   })
+  it('20210102T012345', () => {
+	const date = '20210102T012345'
+	const d = date.match(REGEX_PARSE)
+	expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
+	expect(d.join('-')).toBe('20210102T012345-2021-01-02-01-23-45-')
+  })
+  it('2021-01-02T01:23', () => {
+    const date = '2021-01-02T01:23'
+    const d = date.match(REGEX_PARSE)
+    expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
+    expect(d.join('-')).toBe('2021-01-02T01:23-2021-01-02-01-23--')
+  })
+  it('2021-01-02T01:23:45', () => {
+    const date = '2021-01-02T01:23:45'
+    const d = date.match(REGEX_PARSE)
+    expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
+    expect(d.join('-')).toBe('2021-01-02T01:23:45-2021-01-02-01-23-45-')
+  })
+  it('2021-01-02T01:23:45-0500 (no regex match)', () => {
+    const date = '2021-01-02T01:23:45-0500'
+    const d = date.match(REGEX_PARSE)
+    expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
+    expect(d).toBe(null)
+  })
+  it('2021-01-02T01:23:45Z (no regex match)', () => {
+    const date = '2021-01-02T01:23:45Z'
+    const d = date.match(REGEX_PARSE)
+    expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
+    expect(d).toBe(null)
+  })
 })


### PR DESCRIPTION
To be sure the last digit token in REGEX_PARSE only matches for milliseconds, the period must be escaped. Otherwise, it acts as a wildcard.